### PR TITLE
fix "fatal: No tags can describe 'commitid'."

### DIFF
--- a/git-what-branch
+++ b/git-what-branch
@@ -78,7 +78,7 @@ sub describep($)
     else
     {
       my $newref;
-      chomp($newref = `git describe --tags $ref`);
+      chomp($newref = `git describe --tags --always $ref`);
       $ret = $newref if ($newref && $? == 0);
     }
   }


### PR DESCRIPTION
when running git-what-branch on one of my repos I was getting errors like this:

```
$ git what-branch --allbranches 9844c26
9844c26 used the following minimal temporal path:
fatal: No tags can describe '7a02bfd036cd4873d21fde67d5496c495457a908'.
Try --always, or create some tags.
fatal: No tags can describe '5df6568a2c3de153cff1af56354cdba772c50c84'.
Try --always, or create some tags.
fatal: No tags can describe '326786fd1fa6d395dbfe1ad79eb267fc10aa4863'.
Try --always, or create some tags.
fatal: No tags can describe '9844c264b26a8a5838ab4508c530b185a09ed84f'.
Try --always, or create some tags.
fatal: No tags can describe '7a02bfd036cd4873d21fde67d5496c495457a908'.
Try --always, or create some tags.
```

using the `--always` flag to describe fixed it.
